### PR TITLE
feat: add slack notifications for workflow failures

### DIFF
--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -1,0 +1,70 @@
+name: Slack Notifications
+
+on:
+  workflow_run:
+    workflows: ["*"]  # Monitor all workflows
+    types: [completed]
+
+jobs:
+  notify-slack:
+    if: |
+      github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "❌ Workflow Failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "❌ *Workflow Failed*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow:*\n${{ github.event.workflow_run.name }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Repository:*\n${{ github.repository }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Actor:*\n${{ github.event.workflow_run.actor.login }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:*\n${{ github.event.workflow_run.head_branch }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Workflow"
+                      },
+                      "url": "${{ github.event.workflow_run.html_url }}"
+                    }
+                  ]
+                }
+              ]
+            }


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to monitor all workflow runs
- Send Slack notifications when any workflow fails
- Use official `slackapi/slack-github-action` for reliability

## Implementation Details
- Created `.github/workflows/slack-notifications.yml`
- Monitors all workflows using `workflow_run` event
- Only triggers on workflow failures
- Sends formatted message with workflow details and direct link

## Required Setup
Before merging, please add the following secret to the repository:
- **Secret Name**: `SLACK_WEBHOOK_URL`
- **Secret Value**: The Slack webhook URL provided

## Test Plan
- [ ] Verify workflow file syntax is correct
- [ ] Confirm secret is properly configured
- [ ] Test with a failing workflow to verify notifications work

🤖 Generated with [Claude Code](https://claude.ai/code)