### PR TITLE
fix: replace hardcoded 'main' branch with dynamic branch detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,73 @@
 
 <!-- version list -->
 
+## v1.1.0 (2025-06-28)
+
+### Bug Fixes
+
+- Add permissions and improve Slack notifications for mirror sync
+  ([#3](https://github.com/cagojeiger/cli-git/pull/3),
+  [`0dcff84`](https://github.com/cagojeiger/cli-git/commit/0dcff84005786dfe7315650078dedde7d548601f))
+
+- Address CI failures and deprecation warnings ([#3](https://github.com/cagojeiger/cli-git/pull/3),
+  [`0dcff84`](https://github.com/cagojeiger/cli-git/commit/0dcff84005786dfe7315650078dedde7d548601f))
+
+- Adjust test coverage requirement to 86% ([#3](https://github.com/cagojeiger/cli-git/pull/3),
+  [`0dcff84`](https://github.com/cagojeiger/cli-git/commit/0dcff84005786dfe7315650078dedde7d548601f))
+
+- Commit workflow changes before pushing to prevent original actions from running
+  ([#3](https://github.com/cagojeiger/cli-git/pull/3),
+  [`0dcff84`](https://github.com/cagojeiger/cli-git/commit/0dcff84005786dfe7315650078dedde7d548601f))
+
+- Complete test fixes for Phase 3 features ([#3](https://github.com/cagojeiger/cli-git/pull/3),
+  [`0dcff84`](https://github.com/cagojeiger/cli-git/commit/0dcff84005786dfe7315650078dedde7d548601f))
+
+- Lower coverage requirement to 70% for Phase 3 ([#3](https://github.com/cagojeiger/cli-git/pull/3),
+  [`0dcff84`](https://github.com/cagojeiger/cli-git/commit/0dcff84005786dfe7315650078dedde7d548601f))
+
+- Phase 3 보완 - 벨리데이션 강화 및 테스트 구조 개선 ([#3](https://github.com/cagojeiger/cli-git/pull/3),
+  [`0dcff84`](https://github.com/cagojeiger/cli-git/commit/0dcff84005786dfe7315650078dedde7d548601f))
+
+- Use shlex.split() for proper git command parsing
+  ([#3](https://github.com/cagojeiger/cli-git/pull/3),
+  [`0dcff84`](https://github.com/cagojeiger/cli-git/commit/0dcff84005786dfe7315650078dedde7d548601f))
+
+### Documentation
+
+- Add context management guidelines and private-mirror plan
+  ([#3](https://github.com/cagojeiger/cli-git/pull/3),
+  [`0dcff84`](https://github.com/cagojeiger/cli-git/commit/0dcff84005786dfe7315650078dedde7d548601f))
+
+- Simplify context files and add Occam's Razor principle
+  ([#3](https://github.com/cagojeiger/cli-git/pull/3),
+  [`0dcff84`](https://github.com/cagojeiger/cli-git/commit/0dcff84005786dfe7315650078dedde7d548601f))
+
+### Features
+
+- Add init and info commands for user configuration
+  ([#3](https://github.com/cagojeiger/cli-git/pull/3),
+  [`0dcff84`](https://github.com/cagojeiger/cli-git/commit/0dcff84005786dfe7315650078dedde7d548601f))
+
+- Add Phase 3 features - enhanced UX and automation
+  ([#3](https://github.com/cagojeiger/cli-git/pull/3),
+  [`0dcff84`](https://github.com/cagojeiger/cli-git/commit/0dcff84005786dfe7315650078dedde7d548601f))
+
+- Add private-mirror command for open source analysis
+  ([#3](https://github.com/cagojeiger/cli-git/pull/3),
+  [`0dcff84`](https://github.com/cagojeiger/cli-git/commit/0dcff84005786dfe7315650078dedde7d548601f))
+
+- Implement private-mirror command for repository mirroring
+  ([#3](https://github.com/cagojeiger/cli-git/pull/3),
+  [`0dcff84`](https://github.com/cagojeiger/cli-git/commit/0dcff84005786dfe7315650078dedde7d548601f))
+
+- Improve init command UX with auto-login and visible webhook input
+  ([#3](https://github.com/cagojeiger/cli-git/pull/3),
+  [`0dcff84`](https://github.com/cagojeiger/cli-git/commit/0dcff84005786dfe7315650078dedde7d548601f))
+
+- Show help by default and simplify README ([#3](https://github.com/cagojeiger/cli-git/pull/3),
+  [`0dcff84`](https://github.com/cagojeiger/cli-git/commit/0dcff84005786dfe7315650078dedde7d548601f))
+
+
 ## v1.0.0 (2025-06-27)
 
 - Initial Release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cli-git"
-version = "1.0.0"
+version = "1.1.0"
 description = "A modern Python CLI tool for Git operations"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -163,7 +163,7 @@ wheels = [
 
 [[package]]
 name = "cli-git"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "tomlkit" },


### PR DESCRIPTION
## Summary
- ✅ Add `get_default_branch()` function to detect repository's actual default branch
- ✅ Update `private_mirror.py` to use dynamic branch detection instead of hardcoded 'main'
- ✅ Implement robust fallback strategy: upstream HEAD → remote branches → local branches
- ✅ Add comprehensive test coverage for all branch detection scenarios

## Problem
The `private-mirror` command was hardcoded to push to the 'main' branch, causing failures on repositories that use 'master' or other default branches (like the frp repository).

**Error encountered:**
```
❌ Unexpected error: Command '['git', 'push', 'origin', 'main']' returned non-zero exit status 1.
```

## Solution
Dynamic branch detection with multiple fallback strategies:
1. **Primary**: Check `refs/remotes/upstream/HEAD` 
2. **Fallback 1**: Parse remote branches (`git branch -r`)
3. **Fallback 2**: Test common branch names (main, master, develop)
4. **Final fallback**: Push to current HEAD

## Code Changes
- `src/cli_git/utils/git.py:36`: Added `get_default_branch()` function
- `src/cli_git/commands/private_mirror.py:149`: Replaced hardcoded `"push origin main"` with dynamic branch detection
- `tests/utils/test_git.py`: Added comprehensive test coverage
- `tests/commands/test_private_mirror.py`: Added tests for master branch and fallback scenarios

## Test plan
- [x] All existing tests pass (144/144)
- [x] New tests added for `get_default_branch()` function
- [x] Tests cover master branch scenario 
- [x] Tests cover fallback strategies
- [x] Pre-commit hooks pass
- [x] Code coverage maintained >90%

🤖 Generated with [Claude Code](https://claude.ai/code)