### PR TITLE
fix: add workflows permission to mirror-sync workflow

### DIFF
--- a/src/cli_git/core/workflow.py
+++ b/src/cli_git/core/workflow.py
@@ -21,6 +21,7 @@ def generate_sync_workflow(upstream_url: str, schedule: str, upstream_default_br
 permissions:
   contents: write
   pull-requests: write
+  workflows: write
 
 jobs:
   sync:

--- a/uv.lock
+++ b/uv.lock
@@ -163,7 +163,7 @@ wheels = [
 
 [[package]]
 name = "cli-git"
-version = "1.1.1"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "tomlkit" },


### PR DESCRIPTION
## Summary
- Adds `workflows: write` permission to the mirror-sync workflow
- Fixes the error when pushing tags that contain workflow files

## Problem
When syncing tags from upstream repositories, the following error occurs:
```
refusing to allow a GitHub App to create or update workflow `.github/workflows/labeler.yml` without `workflows` permission
```

## Solution
Added the missing `workflows: write` permission to the GitHub Actions workflow permissions section. This allows the workflow to push tags that contain workflow files.

## Test plan
- [x] Code changes are minimal and focused
- [x] Pre-commit hooks pass
- [x] All tests pass locally
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)