### PR TITLE
refactor: simplify init_command by extracting helper functions

### DIFF
--- a/src/cli_git/commands/init.py
+++ b/src/cli_git/commands/init.py
@@ -40,11 +40,12 @@ def mask_webhook_url(url: str) -> str:
     return "/".join(parts)
 
 
-def init_command(
-    force: Annotated[bool, typer.Option("--force", "-f", help="Force reinitialization")] = False,
-) -> None:
-    """Initialize cli-git configuration with GitHub account information."""
-    # Check gh CLI authentication first
+def ensure_github_auth() -> None:
+    """Ensure GitHub CLI is authenticated.
+
+    Raises:
+        typer.Exit: If authentication fails
+    """
     if not check_gh_auth():
         typer.echo("🔐 GitHub CLI is not authenticated")
         if typer.confirm("Would you like to login now?", default=True):
@@ -57,6 +58,134 @@ def init_command(
         else:
             typer.echo("   Please run: gh auth login")
             raise typer.Exit(1)
+
+
+def select_organization(orgs: list[str]) -> str:
+    """Select organization from list interactively.
+
+    Args:
+        orgs: List of available organizations
+
+    Returns:
+        Selected organization name or empty string for personal account
+    """
+    if not orgs:
+        typer.echo("\n📋 No organizations found. Using personal account.")
+        return ""
+
+    typer.echo("\n📋 Your GitHub organizations:")
+    for i, org in enumerate(orgs, 1):
+        typer.echo(f"   {i}. {org}")
+    typer.echo("   0. No organization (use personal account)")
+
+    while True:
+        choice = typer.prompt("\nSelect organization number", default="0")
+        try:
+            choice_num = int(choice)
+            if choice_num == 0:
+                return ""
+            elif 1 <= choice_num <= len(orgs):
+                return orgs[choice_num - 1]
+            else:
+                typer.echo("Invalid choice. Please try again.")
+        except ValueError:
+            typer.echo("Please enter a number.")
+
+
+def collect_slack_config() -> str:
+    """Collect Slack webhook URL from user.
+
+    Returns:
+        Valid Slack webhook URL or empty string
+    """
+    typer.echo("\n🔔 Slack Integration (optional)")
+    typer.echo("   Enter webhook URL to receive sync failure notifications")
+
+    while True:
+        slack_webhook_url = typer.prompt("Slack webhook URL (optional)", default="")
+        try:
+            validate_slack_webhook_url(slack_webhook_url)
+            return slack_webhook_url
+        except ValidationError as e:
+            typer.echo(str(e))
+            typer.echo("   Press Enter to skip or enter a valid URL")
+
+
+def collect_github_token() -> str:
+    """Collect GitHub Personal Access Token from user.
+
+    Returns:
+        Valid GitHub token or empty string
+    """
+    typer.echo("\n🔑 GitHub Personal Access Token (선택사항)")
+    typer.echo("   태그 동기화를 위해 필요한 권한:")
+    typer.echo("   - repo (전체 저장소 접근)")
+    typer.echo("   - workflow (워크플로우 파일 수정)")
+    typer.echo("")
+    typer.echo("   토큰 생성: https://github.com/settings/tokens/new")
+    typer.echo("   토큰이 없으면 Enter를 누르세요 (태그 동기화가 작동하지 않을 수 있음)")
+
+    while True:
+        github_token = typer.prompt("GitHub Personal Access Token", default="", hide_input=True)
+        if not github_token:
+            typer.echo("   ⚠️  토큰 없이 계속합니다. 태그 동기화가 실패할 수 있습니다.")
+            return ""
+        elif validate_github_token(github_token):
+            typer.echo("   ✓ 토큰이 유효합니다.")
+            return github_token
+        else:
+            typer.echo("   ❌ 유효하지 않은 토큰입니다. 다시 시도하거나 Enter를 눌러 건너뛰세요.")
+
+
+def collect_mirror_prefix() -> str:
+    """Collect default mirror prefix from user.
+
+    Returns:
+        Valid mirror prefix
+    """
+    while True:
+        default_prefix = typer.prompt("\nDefault mirror prefix", default="mirror-")
+        try:
+            validate_prefix(default_prefix)
+            return default_prefix
+        except ValidationError as e:
+            typer.echo(str(e))
+
+
+def show_init_success(
+    username: str, default_org: str, slack_webhook_url: str, github_token: str, default_prefix: str
+) -> None:
+    """Show initialization success message.
+
+    Args:
+        username: GitHub username
+        default_org: Default organization
+        slack_webhook_url: Slack webhook URL
+        github_token: GitHub token
+        default_prefix: Mirror prefix
+    """
+    typer.echo()
+    typer.echo("✅ Configuration initialized successfully!")
+    typer.echo(f"   GitHub username: {username}")
+    if default_org:
+        typer.echo(f"   Default organization: {default_org}")
+    if slack_webhook_url:
+        typer.echo(f"   Slack webhook: {mask_webhook_url(slack_webhook_url)}")
+    if github_token:
+        typer.echo(f"   GitHub token: {mask_token(github_token)}")
+    typer.echo(f"   Mirror prefix: {default_prefix}")
+    typer.echo()
+    typer.echo("Next steps:")
+    typer.echo("- Run 'cli-git info' to see your configuration")
+    typer.echo("- Run 'cli-git private-mirror <repo-url>' to create your first mirror")
+
+
+def init_command(
+    force: Annotated[bool, typer.Option("--force", "-f", help="Force reinitialization")] = False,
+) -> None:
+    """Initialize cli-git configuration with GitHub account information."""
+    # Ensure GitHub CLI is authenticated
+    ensure_github_auth()
 
     # Get current GitHub username
     try:
@@ -78,77 +207,18 @@ def init_command(
         typer.echo("   Use --force to reinitialize")
         return
 
-    # Get user organizations
+    # Get user organizations and select one
     try:
         orgs = get_user_organizations()
-        if orgs:
-            typer.echo("\n📋 Your GitHub organizations:")
-            for i, org in enumerate(orgs, 1):
-                typer.echo(f"   {i}. {org}")
-            typer.echo("   0. No organization (use personal account)")
-
-            # Ask for organization selection
-            while True:
-                choice = typer.prompt("\nSelect organization number", default="0")
-                try:
-                    choice_num = int(choice)
-                    if choice_num == 0:
-                        default_org = ""
-                        break
-                    elif 1 <= choice_num <= len(orgs):
-                        default_org = orgs[choice_num - 1]
-                        break
-                    else:
-                        typer.echo("Invalid choice. Please try again.")
-                except ValueError:
-                    typer.echo("Please enter a number.")
-        else:
-            typer.echo("\n📋 No organizations found. Using personal account.")
-            default_org = ""
+        default_org = select_organization(orgs)
     except GitHubError:
         # Fallback to manual input
         default_org = typer.prompt("\nDefault organization (optional)", default="")
 
-    # Ask for Slack webhook URL
-    typer.echo("\n🔔 Slack Integration (optional)")
-    typer.echo("   Enter webhook URL to receive sync failure notifications")
-    while True:
-        slack_webhook_url = typer.prompt("Slack webhook URL (optional)", default="")
-        try:
-            validate_slack_webhook_url(slack_webhook_url)
-            break
-        except ValidationError as e:
-            typer.echo(str(e))
-            typer.echo("   Press Enter to skip or enter a valid URL")
-
-    # Ask for GitHub Personal Access Token
-    typer.echo("\n🔑 GitHub Personal Access Token (선택사항)")
-    typer.echo("   태그 동기화를 위해 필요한 권한:")
-    typer.echo("   - repo (전체 저장소 접근)")
-    typer.echo("   - workflow (워크플로우 파일 수정)")
-    typer.echo("")
-    typer.echo("   토큰 생성: https://github.com/settings/tokens/new")
-    typer.echo("   토큰이 없으면 Enter를 누르세요 (태그 동기화가 작동하지 않을 수 있음)")
-
-    while True:
-        github_token = typer.prompt("GitHub Personal Access Token", default="", hide_input=True)
-        if not github_token:
-            typer.echo("   ⚠️  토큰 없이 계속합니다. 태그 동기화가 실패할 수 있습니다.")
-            break
-        elif validate_github_token(github_token):
-            typer.echo("   ✓ 토큰이 유효합니다.")
-            break
-        else:
-            typer.echo("   ❌ 유효하지 않은 토큰입니다. 다시 시도하거나 Enter를 눌러 건너뛰세요.")
-
-    # Ask for default mirror prefix
-    while True:
-        default_prefix = typer.prompt("\nDefault mirror prefix", default="mirror-")
-        try:
-            validate_prefix(default_prefix)
-            break
-        except ValidationError as e:
-            typer.echo(str(e))
+    # Collect configuration from user
+    slack_webhook_url = collect_slack_config()
+    github_token = collect_github_token()
+    default_prefix = collect_mirror_prefix()
 
     # Update configuration
     updates = {
@@ -162,18 +232,5 @@ def init_command(
     }
     config_manager.update_config(updates)
 
-    # Success message
-    typer.echo()
-    typer.echo("✅ Configuration initialized successfully!")
-    typer.echo(f"   GitHub username: {username}")
-    if default_org:
-        typer.echo(f"   Default organization: {default_org}")
-    if slack_webhook_url:
-        typer.echo(f"   Slack webhook: {mask_webhook_url(slack_webhook_url)}")
-    if github_token:
-        typer.echo(f"   GitHub token: {mask_token(github_token)}")
-    typer.echo(f"   Mirror prefix: {default_prefix}")
-    typer.echo()
-    typer.echo("Next steps:")
-    typer.echo("- Run 'cli-git info' to see your configuration")
-    typer.echo("- Run 'cli-git private-mirror <repo-url>' to create your first mirror")
+    # Show success message
+    show_init_success(username, default_org, slack_webhook_url, github_token, default_prefix)


### PR DESCRIPTION
## Summary
- Applied Occam's Razor principle to simplify the `init_command` function
- Reduced complexity by extracting logical units into focused helper functions
- Improved code readability and maintainability

## Changes
- **`ensure_github_auth()`**: Handles GitHub CLI authentication check
- **`select_organization()`**: Manages organization selection logic
- **`collect_slack_config()`**: Collects Slack webhook configuration
- **`collect_github_token()`**: Handles GitHub token collection
- **`collect_mirror_prefix()`**: Manages mirror prefix input
- **`show_init_success()`**: Displays success message

## Results
- `init_command` reduced from 136 lines to 44 lines
- Cyclomatic complexity significantly reduced
- All existing tests pass without modification
- Better separation of concerns

## Test plan
- [x] All existing tests pass
- [x] Pre-commit hooks pass
- [x] Manual testing of init command functionality

🤖 Generated with [Claude Code](https://claude.ai/code)