### PR TITLE
feat: apply random schedule to update-mirrors command

### DIFF
--- a/src/cli_git/commands/update_mirrors.py
+++ b/src/cli_git/commands/update_mirrors.py
@@ -22,6 +22,7 @@ from cli_git.utils.gh import (
     get_upstream_default_branch,
 )
 from cli_git.utils.git import extract_repo_info
+from cli_git.utils.schedule import generate_random_biweekly_schedule
 
 
 def update_mirrors_command(
@@ -278,9 +279,12 @@ def _update_mirrors(mirrors: list, github_token: str, slack_webhook_url: str) ->
             # Update workflow file
             typer.echo("  Updating workflow file...")
 
+            # Generate random schedule for better distribution
+            random_schedule = generate_random_biweekly_schedule()
+
             workflow_content = generate_sync_workflow(
                 upstream_url or "https://github.com/PLACEHOLDER/PLACEHOLDER",
-                "0 0 * * *",  # Default schedule
+                random_schedule,  # Use random schedule instead of fixed
                 upstream_branch if upstream_url else "main",
             )
 

--- a/uv.lock
+++ b/uv.lock
@@ -163,7 +163,7 @@ wheels = [
 
 [[package]]
 name = "cli-git"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary
Apply random schedule generation to the update-mirrors command to ensure better distribution of sync times, consistent with private-mirror command behavior.

## Changes
- Import `generate_random_biweekly_schedule` function in update-mirrors command
- Replace fixed schedule (0 0 * * *) with randomly generated schedule
- Ensures better distribution of sync times across mirrors
- Makes behavior consistent with private-mirror command

## Benefits
- Prevents all mirrors from syncing at the same time
- Reduces load on GitHub Actions
- Maintains consistency across mirror commands

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>